### PR TITLE
Add text data type to Open311 data types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.usf.cutr</groupId>
     <artifactId>open311client</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/edu/usf/cutr/open311client/constants/Open311DataType.java
+++ b/src/main/java/edu/usf/cutr/open311client/constants/Open311DataType.java
@@ -24,6 +24,7 @@ package edu.usf.cutr.open311client.constants;
  */
 public class Open311DataType {
   public static final String STRING = "string";
+  public static final String TEXT = "text";
   public static final String NUMBER = "number";
   public static final String DATETIME = "datetime";
   public static final String SINGLEVALUELIST = "singlevaluelist";


### PR DESCRIPTION
To fix Issue [#982](https://github.com/OneBusAway/onebusaway-android/issues/982) in OBA application, the text data type is added to the Open311-client library and and a new version of the open311-client is published in jcenter. 
